### PR TITLE
Fix rollback input validation and cleanup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,25 +73,24 @@ This prepares the indexer safely for upgrade per Wazuh documentation.
 📁 Backups
 Backups are stored in:
 
-swift
-Copy
-Edit
+```
 /var/backups/wazuh_upgrade_<timestamp>/
+```
+
 Log file location:
 
-pgsql
-Copy
-Edit
+```
 /var/log/wazuh_upgrade_<timestamp>.log
+```
+
 🚨 Error Handling
-If any service (wazuh-manager, filebeat, or kibana) fails to start, the script will stop and alert you.
+If any service (`wazuh-manager`, `filebeat`, or `kibana`) fails to start, the script will stop and alert you.
 
 You’ll be able to check logs using:
 
-bash
-Copy
-Edit
+```bash
 journalctl -xeu <service-name>
+```
 
 Docker and multi-node versions
 

--- a/rollback.sh
+++ b/rollback.sh
@@ -29,9 +29,15 @@ echo
 find "$BACKUP_DIR" -maxdepth 1 -type d -name "wazuh_upgrade_*" | sort | nl
 
 read -rp "Enter the number of the backup you want to restore: " selection
+
+# Validate numeric input to prevent sed errors
+if [[ ! "$selection" =~ ^[0-9]+$ ]]; then
+    fail_exit "Selection must be a numeric value."
+fi
+
 SELECTED_BACKUP=$(find "$BACKUP_DIR" -maxdepth 1 -type d -name "wazuh_upgrade_*" | sort | sed -n "${selection}p")
 
-if [[ ! -d "$SELECTED_BACKUP" ]]; then
+if [[ ! -d "$SELECTED_BACKUP" || -z "$SELECTED_BACKUP" ]]; then
     fail_exit "Invalid selection or backup directory not found."
 fi
 


### PR DESCRIPTION
## Summary
- sanitize user selection in `rollback.sh` to avoid `sed` errors
- clean up corrupted README formatting

## Testing
- `bash -n rollback.sh`
- `bash -n wazuh-upgrade.sh`


------
https://chatgpt.com/codex/tasks/task_e_685447db4f30832ab67ba2a4b59e3cac